### PR TITLE
DS-1474 Ensure Addressable version >= 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 19/07/2021 - v5.0.3
+
+* Require Addressable version >= 2.8.0 due to vulnerability: CVE-2021-32740
+* Require Kaminari version >= 1.2.1 due to vulnerability: CVE-2020-11082
+
 # 15/10/2020 - v5.0.2
 
 * Add Ruby 2.7 support

--- a/casino.gemspec
+++ b/casino.gemspec
@@ -23,11 +23,11 @@ Gem::Specification.new do |s|
     s.cert_chain  = ['casino-public_cert.pem']
   end
 
-  s.add_runtime_dependency 'addressable', '>= 2.3'
+  s.add_runtime_dependency 'addressable', '>= 2.8'
   s.add_runtime_dependency 'faraday', '>= 1.1.0'
   s.add_runtime_dependency 'grape', '>= 0.8'
   s.add_runtime_dependency 'grape-entity', '>= 0.4'
-  s.add_runtime_dependency 'kaminari', '~> 0.16'
+  s.add_runtime_dependency 'kaminari', '>= 1.2.1'
   s.add_runtime_dependency 'rails', '>= 4.2'
   s.add_runtime_dependency 'rotp', '~> 3.3.0'
   s.add_runtime_dependency 'rqrcode_png', '>= 0.1'

--- a/config/initializers/kaminari.rb
+++ b/config/initializers/kaminari.rb
@@ -1,3 +1,0 @@
-require 'kaminari'
-
-Kaminari::Hooks.init

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,13 @@
+# config\initializers\kaminari_config.rb
+require 'kaminari'
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+end

--- a/lib/casino/version.rb
+++ b/lib/casino/version.rb
@@ -1,3 +1,3 @@
 module CASino
-  VERSION = '5.0.2'.freeze
+  VERSION = '5.0.3'.freeze
 end

--- a/spec/support/kaminari.rb
+++ b/spec/support/kaminari.rb
@@ -1,3 +1,0 @@
-require 'kaminari'
-
-Kaminari::Hooks.init

--- a/spec/support/kaminari_config.rb
+++ b/spec/support/kaminari_config.rb
@@ -1,0 +1,13 @@
+# config\initializers\kaminari_config.rb
+require 'kaminari'
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+end


### PR DESCRIPTION
- There is a severe security vulnerability in the Addressable gem, 2.3.0 <> 2.7.0. 
- This bumps the gemspec requirement to require 2.8.0 which is the patched version.
  
[Vulnerability page](https://github.com/advisories/GHSA-jxhc-q857-3j6g)
[DS-1474](https://loyaltynz.atlassian.net/jira/servicedesk/projects/DS/queues/custom/35/DS-1474)