### PR TITLE
Ft-992: use YAML.safe_load to preserve aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 5/4/2022 - v5.0.3
+# 5/4/2022 - v5.1.0
 
 * [FT-992](https://loyaltynz.atlassian.net/browse/FT-992): use `YAML.safe_load` instead of `YAML.load`, to preserve aliases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5/4/2022 - v5.0.3
+
+* [FT-992](https://loyaltynz.atlassian.net/browse/FT-992): use `YAML.safe_load` instead of `YAML.load`, to preserve aliases
+
 # 15/10/2020 - v5.0.2
 
 * Add Ruby 2.7 support

--- a/lib/casino/engine.rb
+++ b/lib/casino/engine.rb
@@ -14,7 +14,7 @@ module CASino
 
     private
     def apply_yaml_config(yaml)
-      cfg = (YAML.load(ERB.new(yaml).result)||{}).fetch(Rails.env, {})
+      cfg = (YAML.safe_load(ERB.new(yaml).result, aliases: true) || {}).fetch(Rails.env, {})
       cfg.each do |k,v|
         value = if v.is_a? Hash
           CASino.config.fetch(k.to_sym,{}).merge(v.symbolize_keys)

--- a/lib/casino/version.rb
+++ b/lib/casino/version.rb
@@ -1,3 +1,3 @@
 module CASino
-  VERSION = '5.0.3'.freeze
+  VERSION = '5.1.0'.freeze
 end


### PR DESCRIPTION
## Overview

This is blocking the upgrade of console_sso for [FT-992](https://loyaltynz.atlassian.net/browse/FT-992)

## What is the change?

Use `YAML.safe_load` instead of `YAML.load`, because Ruby's YAML parser (Psych >= 4.0.0) doesn't handle aliases otherwise.

## How was this change made?

`YAML.load(file)` -> `YAML.safe_load(file, aliases: true)`

## How do I use/reproduce this change?

There should be no change to existing behaviour.