### PR TITLE
DS-3587  Automated Monthly Patches - Aug23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 16/08/2022 - v5.2.10
+
+Automated Monthly Patching Aug23
+- Gems updated:
+  - rack 2.2.8 (was 2.2.7)
+  - zeitwerk 2.6.11 (was 2.6.8)
+  - rexml 3.2.6 (was 3.2.5)
+  - websocket-driver 0.7.6 (was 0.7.5) with native extensions
+  - addressable 2.8.5 (was 2.8.4)
+  - faraday 2.7.10 (was 2.7.9)
+  - dry-core 1.0.1 (was 1.0.0)
+  - net-imap 0.3.7 (was 0.3.6)
+
 # 16/08/2022 - v5.2.9
 
 Automated Monthly Patching Jul23

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    casino (5.2.8)
+    casino (5.2.9)
       addressable (>= 2.3)
       faraday (>= 1.1.0)
       grape (>= 0.8)
@@ -82,7 +82,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.4)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     appraisal (2.4.1)
       bundler
@@ -109,7 +109,7 @@ GEM
     crass (1.0.6)
     date (3.3.3)
     diff-lcs (1.5.0)
-    dry-core (1.0.0)
+    dry-core (1.0.1)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
     dry-inflector (1.0.0)
@@ -126,7 +126,7 @@ GEM
     erubi (1.11.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
-    faraday (2.7.9)
+    faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
@@ -176,7 +176,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     mustermann-grape (1.0.2)
       mustermann (>= 1.0.0)
-    net-imap (0.3.6)
+    net-imap (0.3.7)
       date
       net-protocol
     net-pop (0.1.2)
@@ -194,7 +194,7 @@ GEM
       racc (~> 1.4)
     public_suffix (4.0.7)
     racc (1.6.2)
-    rack (2.2.7)
+    rack (2.2.8)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-test (2.0.2)
@@ -231,7 +231,7 @@ GEM
       zeitwerk (~> 2.5)
     rake (13.0.6)
     regexp_parser (2.5.0)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rotp (3.3.1)
     rqrcode (0.7.0)
       chunky_png
@@ -290,12 +290,12 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.7.5)
+    websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.8)
+    zeitwerk (2.6.11)
 
 PLATFORMS
   arm64-darwin-21

--- a/lib/casino/version.rb
+++ b/lib/casino/version.rb
@@ -1,3 +1,3 @@
 module CASino
-  VERSION = '5.2.9'.freeze
+  VERSION = '5.2.10'.freeze
 end


### PR DESCRIPTION
# Automated Monthly Patches
**Base Image:** docker.loyaltydevops.co.nz/service_base_ruby:3.1.2
**Command used:** # bundle update --patch
**Jenkins build:** https://jenkins.loyaltydevops.co.nz/job/TechOps/job/cron-jobs/job/MonthlyPatching/job/bundle_update/747/



## Changes:
- rack 2.2.8 (was 2.2.7)
- zeitwerk 2.6.11 (was 2.6.8)
- rexml 3.2.6 (was 3.2.5)
- websocket-driver 0.7.6 (was 0.7.5) with native extensions
- addressable 2.8.5 (was 2.8.4)
- faraday 2.7.10 (was 2.7.9)
- dry-core 1.0.1 (was 1.0.0)
- net-imap 0.3.7 (was 0.3.6)
